### PR TITLE
Added support for decodeEntities option

### DIFF
--- a/tasks/dom_massager.js
+++ b/tasks/dom_massager.js
@@ -20,8 +20,9 @@ module.exports = function(grunt) {
 			writeDom: false,
 			xmlMode: false,
 			normalizeWhitespace: false,
-			selectors:{},
-			cheerioHook:null
+			decodeEntities: true,
+			selectors: {},
+			cheerioHook: null
 		});
 
 		this.files.forEach(function(f) {
@@ -52,7 +53,8 @@ module.exports = function(grunt) {
 					output,
 					$ = cheerio.load(obj.html, {
 						xmlMode: options.xmlMode,
-						normalizeWhitespace: options.normalizeWhitespace
+						normalizeWhitespace: options.normalizeWhitespace,
+						decodeEntities: options.decodeEntities
 					});
 
 				for(i in options.selectors) {


### PR DESCRIPTION
Hi @dlasky,

Can you please consider this PR please.  I have added support for a further pass-through cheerio option - decodeEntities.  Working with a lot of foreign languages, I find that dom-massager had the unfortunate side-effect of re-writing characters into UTF8 codes.  This patch, allows me to fix that, by setting an option, without disrupting anyone else's use of your excellent Grunt Task.

Many thanks,

Tim 